### PR TITLE
 manifest: Update to BaseApp 24.04 and Runtime 46 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ To Know more about sugar, Please refer to;
 ```
 git clone https://github.com/flathub/org.sugarlabs.Maze.git
 cd org.sugarlabs.Maze
-flatpak -y --user install org.gnome.{Platform,Sdk}//44
+flatpak -y --user install flathub org.gnome.{Platform,Sdk}//46
+flatpak -y --user install org.sugarlabs.BaseApp//24.04
 flatpak-builder --user --force-clean --install build org.sugarlabs.Maze.json
 ```
 

--- a/maze-info.patch
+++ b/maze-info.patch
@@ -2,7 +2,7 @@ diff --git a/activity/activity.info b/activity/activity.info
 index 9d0cf8b..b58a1c4 100644
 --- a/activity/activity.info
 +++ b/activity/activity.info
-@@ -3,9 +3,16 @@ name = Maze
+@@ -3,9 +3,17 @@ name = Maze
  exec = sugar-activity3 activity.MazeActivity
  icon = activity-maze
  activity_version = 32
@@ -22,3 +22,4 @@ index 9d0cf8b..b58a1c4 100644
 +description = Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.
 +screenshots = https://i.imgur.com/imoTbzP.png https://i.imgur.com/GO11pbh.png https://i.imgur.com/RH1koq6.png
 +developer_name = Sugar Labs Community
++developer_id = org.sugarlabs

--- a/maze-info.patch
+++ b/maze-info.patch
@@ -5,7 +5,7 @@ index 9d0cf8b..b58a1c4 100644
 @@ -3,9 +3,16 @@ name = Maze
  exec = sugar-activity3 activity.MazeActivity
  icon = activity-maze
- activity_version = 31
+ activity_version = 32
 +release_date = 2020-02-19
  license = GPLv3+
 -bundle_id = vu.lux.olpc.Maze

--- a/org.sugarlabs.Maze.json
+++ b/org.sugarlabs.Maze.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.Maze",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "23.06",
+    "base-version": "24.04",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",

--- a/org.sugarlabs.Maze.json
+++ b/org.sugarlabs.Maze.json
@@ -26,8 +26,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/sugarlabs/maze-activity.git",
-                    "tag": "v31",
-                    "commit": "9618e80d14165adb9f26cb73d29498ae56132062",
+                    "tag": "v32",
+                    "commit": "b06287bc8cc9c4c98913679bc144baa6d20c5563",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"


### PR DESCRIPTION
updated manifest and README file
maze activity is updated to version 32
and maze-info patch has also been changed to replicate version change.